### PR TITLE
Fix train model to create model_registry dir

### DIFF
--- a/model_training/train_price_model.py
+++ b/model_training/train_price_model.py
@@ -28,5 +28,7 @@ with mlflow.start_run():
     r2 = r2_score(y_val, preds)
     mlflow.log_metric("val_r2", r2)
     # save artefacts
-    joblib.dump(model, BASE_DIR / "model_registry" / "housing_xgb.joblib")
-    joblib.dump(fe,    BASE_DIR / "model_registry" / "fe_pipeline.joblib")
+    model_dir = BASE_DIR / "model_registry"
+    model_dir.mkdir(parents=True, exist_ok=True)
+    joblib.dump(model, model_dir / "housing_xgb.joblib")
+    joblib.dump(fe,    model_dir / "fe_pipeline.joblib")


### PR DESCRIPTION
## Summary
- create the `model_registry` folder before dumping artifacts

## Testing
- `python model_training/train_price_model.py` *(fails: No module named 'mlflow')*

------
https://chatgpt.com/codex/tasks/task_e_686d5d6e89c0832697b913519f209677