### PR TITLE
Handle missing output directories

### DIFF
--- a/data_processing/clean_99acres.py
+++ b/data_processing/clean_99acres.py
@@ -1,3 +1,4 @@
+import pathlib
 import pandas as pd
 from pydantic import BaseModel, ValidationError
 
@@ -21,9 +22,12 @@ def clean(path_in: str, path_out: str):
             good.append(CleanRow(**row.to_dict()).dict())
         except ValidationError:
             continue
+    pathlib.Path(path_out).parent.mkdir(parents=True, exist_ok=True)
     pd.DataFrame(good).to_parquet(path_out, index=False)
 
 if __name__ == "__main__":
     import pathlib
     base = pathlib.Path(__file__).resolve().parent.parent
-    clean(base / "raw_data" / "housing.parquet", base / "processed" / "housing_clean.parquet")
+    default_out = base / "processed" / "housing_clean.parquet"
+    pathlib.Path(default_out).parent.mkdir(parents=True, exist_ok=True)
+    clean(base / "raw_data" / "housing.parquet", default_out)


### PR DESCRIPTION
## Summary
- ensure output directories exist in `clean_99acres.py`
- make the default main path create its parent directory

## Testing
- `python -m py_compile data_processing/clean_99acres.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d5d7015048326ab000c4c409904df